### PR TITLE
XR-004: systemd units for the importer

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,20 @@
+# Deployment (systemd)
+
+`macht-api` is a **oneshot** importer: it runs once (fetch + save), then exits.
+A systemd **timer** triggers it on a schedule (this replaces the previous
+PM2/cron trigger).
+
+```bash
+cargo build --release                       # builds target/release/rust-api
+sudo cp deploy/macht-api.service deploy/macht-api.timer /etc/systemd/system/
+# edit WorkingDirectory / EnvironmentFile / ExecStart paths to match your host
+sudo systemctl daemon-reload
+sudo systemctl enable --now macht-api.timer  # enable the timer, not the service
+systemctl list-timers macht-api.timer        # confirm the schedule
+journalctl -u macht-api -f                   # import logs
+```
+
+The importer runs every minute by default (`OnCalendar=*:0/1`). For a one-off
+full import: `sudo systemctl start macht-api.service` (or run the binary with
+`--full`). Config (`DB_PATH`, external API token, …) comes from the
+`EnvironmentFile` (`.env`), never committed.

--- a/deploy/macht-api.service
+++ b/deploy/macht-api.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=macht-api — match importer (oneshot, triggered by macht-api.timer)
+After=network.target
+
+[Service]
+Type=oneshot
+# Adjust WorkingDirectory / paths to your deployment.
+WorkingDirectory=/opt/football-betting/macht-api
+EnvironmentFile=/opt/football-betting/macht-api/.env
+ExecStart=/opt/football-betting/macht-api/target/release/rust-api

--- a/deploy/macht-api.timer
+++ b/deploy/macht-api.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the macht-api match importer every minute
+
+[Timer]
+OnCalendar=*:0/1
+Persistent=true
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Background

The Rust services are now run under systemd rather than PM2. The importer is a one-shot job that runs and exits, so it needs a timer-driven setup.

## What this changes

Adds reference systemd units — a one-shot service plus a timer that runs the importer every minute — together with short deploy notes, matching how the importer is actually scheduled in production.