### PR TITLE
MA-005: add macht-api CI

### DIFF
--- a/.github/workflows/macht-api-ci.yml
+++ b/.github/workflows/macht-api-ci.yml
@@ -1,0 +1,74 @@
+name: macht-api-ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: macht-api-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Run JS actions on Node 24 (covers actions that still ship a Node 20 runtime).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Throwaway DB for the integration tests — never the shared dev DB.
+  DB_PATH: ${{ github.workspace }}/ci-test.db
+  # Tests share one DB file and reuse match ids, so they must run serially.
+  RUST_TEST_THREADS: "1"
+
+jobs:
+  ci:
+    name: fmt · clippy · test · coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Seed throwaway test database
+        run: |
+          sudo apt-get update && sudo apt-get install -y sqlite3
+          sqlite3 "$DB_PATH" 'CREATE TABLE `match` (
+            `id` integer PRIMARY KEY NOT NULL,
+            `homeTeam` text NOT NULL,
+            `awayTeam` text NOT NULL,
+            `status` text NOT NULL,
+            `utcDate` integer NOT NULL,
+            `score` text,
+            `homeScore` integer,
+            `awayScore` integer
+          );'
+          sqlite3 "$DB_PATH" 'PRAGMA journal_mode=WAL;'
+
+      - name: Tests
+        run: cargo test --locked
+
+      - name: Install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-tarpaulin
+
+      - name: Coverage
+        run: cargo tarpaulin --out Xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: football-betting/macht-api
+          files: ./cobertura.xml
+          fail_ci_if_error: false

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,8 @@
 # Rust Api
 
+[![macht-api-ci](https://github.com/football-betting/macht-api/actions/workflows/macht-api-ci.yml/badge.svg)](https://github.com/football-betting/macht-api/actions/workflows/macht-api-ci.yml)
+[![codecov](https://codecov.io/gh/football-betting/macht-api/branch/master/graph/badge.svg)](https://codecov.io/gh/football-betting/macht-api)
+
 ### How to
 - insert your key.json into the tmp directory
 - execute `cp .env.dist .env`

--- a/src/api/match_client.rs
+++ b/src/api/match_client.rs
@@ -231,17 +231,13 @@ impl MatchClient {
                 // Shared DB with frontend + betting-api: wait for the lock
                 // instead of failing with SQLITE_BUSY, and use WAL so the
                 // importer's writes don't block readers.
-                if let Err(e) =
-                    conn.busy_timeout(std::time::Duration::from_millis(5000))
-                {
+                if let Err(e) = conn.busy_timeout(std::time::Duration::from_millis(5000)) {
                     eprintln!("macht-api: failed to set busy_timeout: {e}");
                     return None;
                 }
-                if let Err(e) =
-                    conn.query_row("PRAGMA journal_mode = WAL", [], |row| {
-                        row.get::<_, String>(0)
-                    })
-                {
+                if let Err(e) = conn.query_row("PRAGMA journal_mode = WAL", [], |row| {
+                    row.get::<_, String>(0)
+                }) {
                     eprintln!("macht-api: failed to enable WAL: {e}");
                     return None;
                 }


### PR DESCRIPTION
## Background

macht-api had no continuous integration. Its tests are integration tests that operate on a SQLite database which must already hold the match schema; run locally they go against the shared development database, which is unsafe to rely on in automation.

## What this changes

The service now has a CI pipeline that checks formatting, lints, and runs the test suite on every push and pull request, then reports coverage. The tests run against a throwaway database seeded for the run, so they never touch shared state. Build status and coverage are surfaced as badges in the README. A small pre-existing formatting drift was also corrected so the format check passes.
