### PR TITLE
MA-006: unit tests for score helper and team logic

### DIFF
--- a/src/api/match_client.rs
+++ b/src/api/match_client.rs
@@ -514,4 +514,39 @@ mod tests {
             TEAM_FIELD_MAX_LEN
         );
     }
+
+    fn team(name: Option<&str>, tla: Option<&str>) -> Team {
+        Team {
+            id: None,
+            name: name.map(str::to_string),
+            shortName: None,
+            tla: tla.map(str::to_string),
+            flag: None,
+        }
+    }
+
+    #[test]
+    fn team_determined_true_when_name_or_tla_present() {
+        assert!(MatchClient::team_determined(&team(Some("Germany"), None)));
+        assert!(MatchClient::team_determined(&team(None, Some("GER"))));
+        assert!(MatchClient::team_determined(&team(
+            Some("Germany"),
+            Some("GER")
+        )));
+    }
+
+    #[test]
+    fn team_determined_false_when_null_or_blank() {
+        assert!(!MatchClient::team_determined(&team(None, None)));
+        // Whitespace-only / empty strings are treated as undetermined.
+        assert!(!MatchClient::team_determined(&team(Some("   "), Some(""))));
+    }
+
+    #[test]
+    fn normalize_team_fills_nulls_with_empty_strings() {
+        let mut t = team(None, Some("GER"));
+        MatchClient::normalize_team(&mut t);
+        assert_eq!(t.name.as_deref(), Some(""));
+        assert_eq!(t.tla.as_deref(), Some("GER"));
+    }
 }

--- a/src/service/score_helper.rs
+++ b/src/service/score_helper.rs
@@ -15,3 +15,78 @@ impl ScoreHelper {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::match_client::{Score, ScoreDetail, Team};
+
+    fn team() -> Team {
+        Team {
+            id: Some(1),
+            name: Some("Team".to_string()),
+            shortName: None,
+            tla: Some("TEA".to_string()),
+            flag: None,
+        }
+    }
+
+    fn match_with(
+        full: (Option<isize>, Option<isize>),
+        regular: Option<(Option<isize>, Option<isize>)>,
+    ) -> Match {
+        Match {
+            id: 1,
+            utcDate: "2026-06-11T19:00:00Z".to_string(),
+            homeTeam: team(),
+            awayTeam: team(),
+            score: Score {
+                winner: None,
+                duration: "REGULAR".to_string(),
+                fullTime: ScoreDetail {
+                    home: full.0,
+                    away: full.1,
+                },
+                halfTime: ScoreDetail {
+                    home: None,
+                    away: None,
+                },
+                regularTime: regular.map(|(home, away)| ScoreDetail { home, away }),
+            },
+            status: "FINISHED".to_string(),
+            homeScore: None,
+            awayScore: None,
+        }
+    }
+
+    #[test]
+    fn uses_full_time_when_no_regular_time() {
+        let mut matches = vec![match_with((Some(2), Some(1)), None)];
+        ScoreHelper::set_home_and_away_score(&mut matches);
+        assert_eq!(matches[0].homeScore, Some(2));
+        assert_eq!(matches[0].awayScore, Some(1));
+    }
+
+    #[test]
+    fn prefers_regular_time_over_full_time() {
+        // Knockout decided in extra time: fullTime includes ET, regularTime is
+        // the 90-minute score the app scores against.
+        let mut matches = vec![match_with((Some(3), Some(2)), Some((Some(1), Some(1))))];
+        ScoreHelper::set_home_and_away_score(&mut matches);
+        assert_eq!(matches[0].homeScore, Some(1));
+        assert_eq!(matches[0].awayScore, Some(1));
+    }
+
+    #[test]
+    fn carries_nulls_and_handles_multiple_matches() {
+        let mut matches = vec![
+            match_with((None, None), None),
+            match_with((Some(0), Some(0)), None),
+        ];
+        ScoreHelper::set_home_and_away_score(&mut matches);
+        assert_eq!(matches[0].homeScore, None);
+        assert_eq!(matches[0].awayScore, None);
+        assert_eq!(matches[1].homeScore, Some(0));
+        assert_eq!(matches[1].awayScore, Some(0));
+    }
+}


### PR DESCRIPTION
## Background
The importer's pure logic was only partially covered: the score selection
(regular-time vs full-time) had no test, and team determination and field
normalization were exercised only indirectly through the database-backed import
tests.

## What this changes
Adds database-free unit tests for the score helper (regular-time preference,
full-time fallback, null and multi-match handling) and for the
team-determination and normalization helpers (present vs blank fields, null
fields normalized to empty strings). These run without a database, so they cover
the core logic directly and quickly.