### PR TITLE
MA-009: cover get_matches HTTP paths + connection error branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +68,16 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -246,6 +265,24 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "displaydoc"
@@ -505,6 +542,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +606,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -831,6 +881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +959,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1101,6 +1167,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1287,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -2082,6 +2178,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ chrono = "0.4.44"
 rusqlite = "0.40"
 serde_json = "1.0.150"
 clap = { version = "4.6.1", features = ["derive"] }
+
+[dev-dependencies]
+wiremock = "0.6.5"

--- a/src/api/match_client.rs
+++ b/src/api/match_client.rs
@@ -260,6 +260,8 @@ impl MatchClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{header, method, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
     async fn save_matches_to_sqlite_inserts_new_match() {
@@ -759,5 +761,130 @@ mod tests {
         cleanup(&path);
 
         assert_eq!(total, WRITERS * ROWS_PER_WRITER);
+    }
+
+    // --- get_matches: upstream HTTP paths (mock server) ---
+    //
+    // These mutate process-global env (API_URI / X_AUTH_TOKEN / DB_PATH). The
+    // suite already runs serially in CI (RUST_TEST_THREADS=1) because the
+    // DB-backed tests share one DB_PATH, so the env mutation is safe here too.
+    // dotenvy::dotenv() does not override already-set vars, so the values set
+    // below win over any .env file.
+
+    const SINGLE_MATCH_BODY: &str = r#"{
+        "matches": [{
+            "id": 700001,
+            "utcDate": "2026-06-11T19:00:00Z",
+            "homeTeam": {"id": 1, "name": "Germany", "shortName": "GER", "tla": "GER", "crest": null},
+            "awayTeam": {"id": 2, "name": "Scotland", "shortName": "SCO", "tla": "SCO", "crest": null},
+            "score": {"winner": null, "duration": "REGULAR", "fullTime": {"home": null, "away": null}, "halfTime": {"home": null, "away": null}},
+            "status": "TIMED",
+            "homeScore": null,
+            "awayScore": null
+        }]
+    }"#;
+
+    #[tokio::test]
+    async fn get_matches_parses_successful_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(SINGLE_MATCH_BODY, "application/json"),
+            )
+            .mount(&server)
+            .await;
+        std::env::set_var("API_URI", server.uri());
+        std::env::set_var("X_AUTH_TOKEN", "test-token");
+
+        let result = MatchClient::get_matches(None).await;
+
+        let matches = result.expect("Some result").matches.expect("matches");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].id, 700001);
+        assert_eq!(matches[0].homeTeam.tla.as_deref(), Some("GER"));
+    }
+
+    #[tokio::test]
+    async fn get_matches_sends_auth_header_and_date_query() {
+        let server = MockServer::start().await;
+        // The mock only matches when the auth header and both date params are
+        // present, so a 200 here proves get_matches built the request correctly.
+        Mock::given(method("GET"))
+            .and(header("X-Auth-Token", "secret-xyz"))
+            .and(query_param("dateFrom", "2026-06-11"))
+            .and(query_param("dateTo", "2026-06-11"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(r#"{"matches":[]}"#, "application/json"),
+            )
+            .mount(&server)
+            .await;
+        std::env::set_var("API_URI", server.uri());
+        std::env::set_var("X_AUTH_TOKEN", "secret-xyz");
+
+        let result = MatchClient::get_matches(Some("2026-06-11".to_string())).await;
+
+        assert_eq!(
+            result.expect("Some result").matches.expect("matches").len(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn get_matches_returns_none_on_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+        std::env::set_var("API_URI", server.uri());
+        std::env::set_var("X_AUTH_TOKEN", "test-token");
+
+        assert!(MatchClient::get_matches(None).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_matches_returns_none_on_malformed_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw("definitely not json", "application/json"),
+            )
+            .mount(&server)
+            .await;
+        std::env::set_var("API_URI", server.uri());
+        std::env::set_var("X_AUTH_TOKEN", "test-token");
+
+        assert!(MatchClient::get_matches(None).await.is_none());
+    }
+
+    // --- get_connection: error branches (save/restore DB_PATH for the suite) ---
+
+    #[tokio::test]
+    async fn save_matches_is_noop_when_db_path_unset() {
+        let saved = std::env::var("DB_PATH").ok();
+        std::env::remove_var("DB_PATH");
+
+        let mut matches = vec![sample_match(199990, "2022-01-01T00:00:00Z")];
+        // Graceful no-op: get_connection returns None, save_matches returns.
+        MatchClient::save_matches_to_sqlite(&mut matches).await;
+
+        if let Some(v) = saved {
+            std::env::set_var("DB_PATH", v);
+        }
+    }
+
+    #[tokio::test]
+    async fn save_matches_is_noop_when_db_path_unopenable() {
+        let saved = std::env::var("DB_PATH").ok();
+        std::env::set_var("DB_PATH", "/nonexistent-dir-xyz/cannot/open.db");
+
+        let mut matches = vec![sample_match(199991, "2022-01-01T00:00:00Z")];
+        // Connection::open fails -> get_connection None -> no panic, no write.
+        MatchClient::save_matches_to_sqlite(&mut matches).await;
+
+        match saved {
+            Some(v) => std::env::set_var("DB_PATH", v),
+            None => std::env::remove_var("DB_PATH"),
+        }
     }
 }


### PR DESCRIPTION
## Background

MA-008 raised importer coverage but left the largest untested block — the whole upstream HTTP call (`get_matches`: environment reads, request, status handling, JSON parsing) — and the database connection error branches uncovered. Those are the "upstream is down / returns garbage / DB path misconfigured" paths that matter most in production.

## What this changes

- Adds `wiremock` as a dev-dependency and tests `get_matches` against a mock HTTP server: a successful payload parses; the auth header and date-range query are sent correctly; a non-success status returns nothing; a malformed body returns nothing.
- Adds tests for the connection error branches: an unset and an unopenable database path both make the save a graceful no-op rather than a panic. These save and restore the environment variable so the serial suite is unaffected.

Test-only plus a dev-dependency — no production code change, so no deployment is required (dev-dependencies are excluded from the release binary).