### PR TITLE
MA-010: 3x/day full-import timer to finalize UTC-midnight rollover matches

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -18,3 +18,28 @@ The importer runs every minute by default (`OnCalendar=*:0/1`). For a one-off
 full import: `sudo systemctl start macht-api.service` (or run the binary with
 `--full`). Config (`DB_PATH`, external API token, …) comes from the
 `EnvironmentFile` (`.env`), never committed.
+
+## Full-import safety timer (UTC-midnight rollover) — MA-010
+
+The per-minute importer fetches only the current **UTC day**. A match that kicks
+off late (e.g. 22:00 UTC) and is only marked `FINISHED` upstream after 00:00 UTC
+is never re-fetched, so its `status` stays stuck at `IN_PLAY`/`PAUSED` (the
+frontend then shows a finished game as "live"). A second timer runs the importer
+with `--full` (no date filter) 3×/day to re-sync past days and finalize these
+stragglers. A full import is a single upstream request, so 3×/day is negligible.
+
+```bash
+sudo cp deploy/macht-api-full.service deploy/macht-api-full.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now macht-api-full.timer
+systemctl list-timers macht-api-full.timer
+```
+
+`OnCalendar=*-*-* 02,10,18:00:00 UTC` needs **systemd ≥ 252** (trailing-timezone
+support). On **systemd < 252**, drop the `UTC` suffix and use the local-time
+equivalents — e.g. on `Europe/Berlin`: `OnCalendar=*-*-* 04,12,20:00:00`
+(= 02/10/18 UTC in CEST; in winter it drifts −1 h, which is harmless — the only
+requirement is that one run lands after 00:00 UTC).
+
+**Already installed & enabled (2026-06-14):** valantic (systemd 255, UTC form)
+and fuhlingen (systemd 249, local `04,12,20:00:00` Europe/Berlin).

--- a/deploy/macht-api-full.service
+++ b/deploy/macht-api-full.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=macht-api — full match importer (all dates; catches UTC-midnight rollover stragglers)
+After=network.target
+
+[Service]
+Type=oneshot
+# Adjust WorkingDirectory / paths to your deployment.
+WorkingDirectory=/opt/football-betting/macht-api
+EnvironmentFile=/opt/football-betting/macht-api/.env
+ExecStart=/opt/football-betting/macht-api/target/release/rust-api --full

--- a/deploy/macht-api-full.timer
+++ b/deploy/macht-api-full.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the macht-api full importer 3x/day (02:00/10:00/18:00 UTC)
+
+[Timer]
+# systemd >= 252 supports the trailing timezone. On older systemd (< 252) drop
+# the "UTC" suffix and use local-time equivalents instead — see deploy README.
+OnCalendar=*-*-* 02,10,18:00:00 UTC
+Persistent=true
+AccuracySec=1m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Background
The per-minute importer fetches only the current UTC day (`dateFrom=today&dateTo=today`). A fixture that kicks off late in the UTC day (e.g. 22:00 UTC) and is only marked `FINISHED` upstream after 00:00 UTC is never re-fetched — from the next minute the importer queries the new UTC day, so the late match freezes at its last-written status (`IN_PLAY`/`PAUSED`). The frontend renders those statuses as "live", so a finished game shows as live indefinitely. This bit production on 2026-06-14: Brazil–Morocco stayed "live" for ~19 h until a manual full import resolved it.

## What this changes
Adds a second systemd timer (`macht-api-full.{service,timer}`) that runs the importer with `--full` (no date filter) three times a day, re-syncing past days so rollover stragglers get finalized. The per-minute live importer is untouched. A full import is a single upstream request, so 3×/day adds negligible load. The deploy README documents install plus the systemd ≥252 (`… UTC`) form and the <252 local-time fallback. The timer is already installed and enabled on both production servers (valantic, fuhlingen).