### PR TITLE
MA-011: widen incremental import window across UTC midnight

### DIFF
--- a/src/api/match_client.rs
+++ b/src/api/match_client.rs
@@ -56,7 +56,7 @@ const BUSY_TIMEOUT_MS: u64 = 5000;
 pub struct MatchClient {}
 
 impl MatchClient {
-    pub async fn get_matches(date: Option<String>) -> Option<ApiResult> {
+    pub async fn get_matches(date_range: Option<(String, String)>) -> Option<ApiResult> {
         dotenv().ok();
 
         let mut uri = match env::var("API_URI") {
@@ -64,8 +64,8 @@ impl MatchClient {
             Err(_) => "Error loading env variable API_URI".to_string(),
         };
 
-        uri = match date {
-            Some(d) => uri + "?dateFrom=" + d.as_str() + "&dateTo=" + d.as_str(),
+        uri = match date_range {
+            Some((from, to)) => uri + "?dateFrom=" + from.as_str() + "&dateTo=" + to.as_str(),
             None => uri,
         };
 
@@ -811,8 +811,8 @@ mod tests {
         // present, so a 200 here proves get_matches built the request correctly.
         Mock::given(method("GET"))
             .and(header("X-Auth-Token", "secret-xyz"))
-            .and(query_param("dateFrom", "2026-06-11"))
-            .and(query_param("dateTo", "2026-06-11"))
+            .and(query_param("dateFrom", "2026-06-10"))
+            .and(query_param("dateTo", "2026-06-12"))
             .respond_with(
                 ResponseTemplate::new(200).set_body_raw(r#"{"matches":[]}"#, "application/json"),
             )
@@ -821,7 +821,9 @@ mod tests {
         std::env::set_var("API_URI", server.uri());
         std::env::set_var("X_AUTH_TOKEN", "secret-xyz");
 
-        let result = MatchClient::get_matches(Some("2026-06-11".to_string())).await;
+        let result =
+            MatchClient::get_matches(Some(("2026-06-10".to_string(), "2026-06-12".to_string())))
+                .await;
 
         assert_eq!(
             result.expect("Some result").matches.expect("matches").len(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,15 @@ struct Args {
     full: bool,
 }
 
+/// Inclusive `(dateFrom, dateTo)` window for the per-minute incremental import.
+/// Spans `today-1 .. today+1` (UTC) so a match still in play across the 00:00 UTC
+/// rollover stays inside the queried range and keeps updating to its final score,
+/// instead of freezing at its last pre-midnight state.
+fn incremental_window(today: chrono::NaiveDate) -> (String, String) {
+    let one_day = chrono::Duration::days(1);
+    ((today - one_day).to_string(), (today + one_day).to_string())
+}
+
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -21,7 +30,10 @@ async fn main() {
     let api_result: Option<ApiResult> = if args.full {
         MatchClient::get_matches(None).await
     } else {
-        MatchClient::get_matches(Some(chrono::offset::Utc::now().date_naive().to_string())).await
+        MatchClient::get_matches(Some(incremental_window(
+            chrono::offset::Utc::now().date_naive(),
+        )))
+        .await
     };
 
     let mut api_result = match api_result {
@@ -35,5 +47,27 @@ async fn main() {
     if let Some(matches) = api_result.matches.as_mut() {
         ScoreHelper::set_home_and_away_score(matches);
         MatchClient::save_matches_to_sqlite(matches).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::incremental_window;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn incremental_window_spans_yesterday_to_tomorrow() {
+        let today = NaiveDate::from_ymd_opt(2026, 6, 18).expect("valid date");
+        let (from, to) = incremental_window(today);
+        assert_eq!(from, "2026-06-17");
+        assert_eq!(to, "2026-06-19");
+    }
+
+    #[test]
+    fn incremental_window_crosses_month_boundary() {
+        let today = NaiveDate::from_ymd_opt(2026, 7, 1).expect("valid date");
+        let (from, to) = incremental_window(today);
+        assert_eq!(from, "2026-06-30");
+        assert_eq!(to, "2026-07-02");
     }
 }


### PR DESCRIPTION
## Background

Late-evening matches showed a wrong, frozen score on the live site after midnight
UTC. On 2026-06-18 Ghana–Panama (kickoff 23:00 UTC) was stuck at 0:0 / half-time
long after it had actually finished 1:0, because the live importer stopped looking
at the match once the UTC day rolled over. The whole second half was missing until
a manual re-sync. The existing 3×/day full re-import only repairs this hours later.

## What this changes

The per-minute importer now queries a three-day window (yesterday … tomorrow,
UTC) instead of only the current UTC day. A match that is still in play across
00:00 UTC stays inside the queried range and keeps updating every minute until it
finalizes — no more frozen scores, no waiting for the safety re-import. The
full-import mode (`--full`) is unchanged and stays as a belt-and-braces backstop.
